### PR TITLE
Joining and leaving rooms does not require the # anymore.

### DIFF
--- a/src/com/cavariux/twitchirc/Core/TwitchBot.java
+++ b/src/com/cavariux/twitchirc/Core/TwitchBot.java
@@ -220,9 +220,10 @@ public class TwitchBot {
 	 */
 	public final Channel joinChannel (String channel)
 	{
-		sendRawMessage("JOIN " + channel + "\r\n");
-		System.out.println("> JOIN " + channel);
-		return Channel.getChannel(channel, this);
+		Channel cnl = Channel.getChannel(channel, this);
+		sendRawMessage("JOIN " + cnl + "\r\n");
+		System.out.println("> JOIN " + cnl);
+		return cnl;
 	}
 	
 	/**
@@ -231,8 +232,9 @@ public class TwitchBot {
 	 */
 	public final void partChannel (String channel)
 	{
-		this.sendRawMessage("PART " + channel);
-		this.channels.remove(channel);
+		Channel cnl = Channel.getChannel(channel, this);
+		this.sendRawMessage("PART " + cnl);
+		this.channels.remove(cnl);
 		System.out.println("> PART " + channel);
 	}
 	


### PR DESCRIPTION
To add consistency as for the Channel.getChannel() method.